### PR TITLE
Small code fix in cache expiration example

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-cache-expiration.md
+++ b/src/content/en/tools/workbox/modules/workbox-cache-expiration.md
@@ -89,7 +89,7 @@ const expirationManager = new workbox.expiration.CacheExpiration(
   cacheName,
   {
     maxAgeSeconds: 24 * 60 * 60,
-    maxEntries 20,
+    maxEntries: 20,
   }
 );
 ```


### PR DESCRIPTION
What's changed, or what was fixed?
- small code typo in cache expiration page

**Fixes:** n/a

**Target Live Date:** n/a

- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
